### PR TITLE
Add Retry on Status Code Over 500

### DIFF
--- a/index.js
+++ b/index.js
@@ -205,10 +205,12 @@ function sendRequest(client, device, message, projectId, accessToken, doneCallba
             // Convert response body to JSON object
             let response = JSON.parse(data);
 
+            // Extract status code from JSON response object
             let statusCode = response.statusCode ?? response.status;
-
+            // Status code found?
             if (statusCode) {
-                if (statusCode > 500) { // FCM service temporarily unavailable
+                // Server-side error?
+                if (statusCode >= 500) {
                     // Retry request using same HTTP2 session in 10 seconds
                     return setTimeout(() => { sendRequest.apply(this, args) }, 10 * 1000);
                 }

--- a/index.js
+++ b/index.js
@@ -202,6 +202,11 @@ function sendRequest(client, device, message, projectId, accessToken, doneCallba
     // Response received in full
     request.on('end', () => {
         try {
+            // Server-side error? (may be returned as HTML, so search text explicitly before try parsing from JSON)
+            if (data.toLowerCase().includes('server error')) {
+                return errorHandler(new Error('Internal Server Error'));
+            }
+            
             // Convert response body to JSON object
             let response = JSON.parse(data);
 

--- a/index.js
+++ b/index.js
@@ -207,12 +207,13 @@ function sendRequest(client, device, message, projectId, accessToken, doneCallba
 
             // Extract status code from JSON response object
             let statusCode = response.statusCode ?? response.status;
+            
             // Status code found?
             if (statusCode) {
                 // Server-side error?
                 if (statusCode >= 500) {
                     // Retry request using same HTTP2 session in 10 seconds
-                    return setTimeout(() => { sendRequest.apply(this, args) }, 10 * 1000);
+                    return errorHandler(new Error(statusCode + 'Internal Server Error'));
                 }
             }
             

--- a/index.js
+++ b/index.js
@@ -211,6 +211,10 @@ function sendRequest(client, device, message, projectId, accessToken, doneCallba
                 if (response.error.details && response.error.details[0].errorCode === 'UNREGISTERED') {
                     // Add to unregistered tokens list
                     client.unregisteredTokens.push(device);
+                } 
+                else if (response.status > 500) { // FCM service temporarily unavailable
+                    // Retry request using same HTTP2 session in 10 seconds
+                    return setTimeout(() => { sendRequest.apply(this, args) }, 10 * 1000);
                 }
                 else {
                     // Call async done callback with error


### PR DESCRIPTION
This aligns with the logic of `node-gcm`, and reduces the error spam coming from the package. For applications with a large and consistent stream of notifications, the FCM 'service temporarily unavailable' error appears often (a handful of times per week). This error is transient and is easily circumvented by retrying the request. This change retries the failing request after 10 seconds if a 500+ status code is received, which aligns with the 503 associated with the 'unavailable' error.